### PR TITLE
docs(): Add pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,27 @@
+## Sumary
+
+This pull request includes the following changes:
+- [Description of the changes]
+
+
+## Problems _(if existing)_
+
+There are those issues orruring:
+- [Description of the issue; reference to the bugtracker]
+
+
+## Checks
+
+- [ ] Wrote unit tests for the code?
+- [ ] Does all tests passed properly?
+- [ ] Changed documentation files if necessary?
+- [ ] Used docstrings for getting support from the editor?
+- [ ] Followed the PEP-8 conevntions?
+
+
+## Additional Information
+
+[Optional: Any additional information that might be useful for reviewers to understand the changes]
+
+
+[References to closed issues]


### PR DESCRIPTION
Unify PRs by using a general template.
Create the template to cover everything possible.
Although anyone is forced to use all the suggested points so a real PR might be a bit shorted than suggested by the template.