### PR TITLE
Display high score without whitespace

### DIFF
--- a/src/score.py
+++ b/src/score.py
@@ -18,9 +18,9 @@ class Score(GameElement):
         super().__init__(config.display_scale[0], 0)
         self.OBJECT_SPEED = 0
 
-        self.immages: tuple[list[pg.Surface], pg.Rect, pg.Rect]
-        self.immages = seperate_images(load_image("numbers.png")[0], (12, 1))
-        self.immage, self.position_rect, self.hitbox = self.immages
+        self.images: tuple[list[pg.Surface], pg.Rect, pg.Rect]
+        self.images = seperate_images(load_image("numbers.png")[0], (12, 1))
+        self.image, self.position_rect, self.hitbox = self.images
 
     def split_number(self, number: int) -> list[int]:
         """Split an int into a list of digits of a length of five
@@ -46,11 +46,11 @@ class Score(GameElement):
             The position is counted from the right of the leftmost character
             to the right side of the screen
             characters (list[int]): The list of characters to be displayed
-            It refers to the immage list of the Score class
+            It refers to the image list of the Score class
         """
 
         for i, character in enumerate(characters):
-            self.current_image = self.immage[character]
+            self.current_image = self.image[character]
             self.position_rect.x = config.display_scale[0] - position + i * 25
             config.window.blit(self.current_image, self.position_rect)
 

--- a/src/score.py
+++ b/src/score.py
@@ -38,17 +38,32 @@ class Score(GameElement):
         digits.reverse()
         return digits
 
+    def _display_characters(self, position: int, characters: list[int]) -> None:
+        """Display a list of characters on the screen
+
+        Args:
+            position (int): The position on the screen
+            The position is counted from the right of the leftmost character
+            to the right side of the screen
+            characters (list[int]): The list of characters to be displayed
+            It refers to the immage list of the Score class
+        """
+
+        for i, character in enumerate(characters):
+            self.current_image = self.immage[character]
+            self.position_rect.x = config.display_scale[0] - position + i * 25
+            config.window.blit(self.current_image, self.position_rect)
+
     def display_highscore(self) -> None:
         """Display the highscore on the screen"""
         highscore: int = self.counter.highscore
         digits: list[int] = self.split_number(highscore)
-        digits.insert(0, 10)
-        digits.insert(1, 11)
 
-        for i, digit in enumerate(digits):
-            self.current_image = self.immage[digit]
-            self.position_rect.x = config.display_scale[0] - 350 + i * 25
-            config.window.blit(self.current_image, self.position_rect)
+        self._display_characters(300, digits)
+
+        digits = [10, 11]
+
+        self._display_characters(365, digits)
 
     def update(self) -> None:
         # At first the singulat chars are seperated and
@@ -56,9 +71,4 @@ class Score(GameElement):
         sore: int = self.counter.score
         digits: list[int] = self.split_number(sore)
 
-        # The immages are then filled up with the digits
-        # and the immages are blit to the screen
-        for i, digit in enumerate(digits):
-            self.current_image = self.immage[digit]
-            self.position_rect.x = config.display_scale[0] - 125 + i * 25
-            config.window.blit(self.current_image, self.position_rect)
+        self._display_characters(125, digits)

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,16 +1,21 @@
 # type: ignore
-# pylint: disable=missing-docstring, no-member
+# pylint: disable=missing-docstring, no-member, disable=protected-access
 import unittest
 from unittest.mock import Mock, patch
 
 import pygame as pg
 
 from score import Score
+from config import config
 
 
 class TestScore(unittest.TestCase):
     def setUp(self):
-        pg.init()
+        config.display_scale = (800, 600)
+        config.caption = "Dino"
+        config.background_color = pg.Color(255, 255, 255)
+        config.init_game()
+
         self.score = Score()
         self.score.counter = Mock()
 
@@ -40,6 +45,12 @@ class TestScore(unittest.TestCase):
         self.score.update()
         self.assertEqual(mock_config.window.blit.call_count, 5)
 
+    @patch("score.config")
+    def test_display_characters(self, mock_config):
+        mock_config.display_scale = (800, 600)
+        test_characters = [1, 2, 3]
+        test_position = 100
 
-if __name__ == "__main__":
-    unittest.main()
+        self.score._display_characters(test_position, test_characters)
+
+        self.assertEqual(mock_config.window.blit.call_count, 3)

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock, patch
 
 import pygame as pg
 
-from score import Score
 from config import config
+from score import Score
 
 
 class TestScore(unittest.TestCase):


### PR DESCRIPTION
## Summary
This pull request includes the following changes:
- After the `HI` that indicates the High score a whitespace of 10 px is now displayed.
- The functionality to display a row of digits is as well separated in a function to reuse this code.


## Problems
There issues currently exist:
- #74 


## Checks
- [x] Wrote unit tests for the code?
- [ ] Changed documentation files if necessary?
- [x] Used doc strings for getting support from the editor?

#73 [Display High score without whitespace](https://github.com/RedLion8399/Dino/issues/73)